### PR TITLE
Correct/clarify documentation, implement admonitions

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,28 +8,11 @@ sidebar_position: 1
 
 Subscribe to stay up to date with new updates: [Subscribe 📨](https://817715f5.sibforms.com/serve/MUIEAMf2kzgJKDLrfbc46jFqp1U2BCxtNd2G2YfHO_4Wdqvdj0FqFJzy7a-_iVFmCKBzuSIjfoqot4O8DJXEj288d_YmAXXYKQCe34E0CseCIq7Ozvg90PktET7eeGdlTtrSc5f4S4pMYkyrJdQRSjLyur5_l1r3mUyCbDahOq4M8Jc5Hy-c9ZX_wkX-qt5lH0ORt6ePXfyRrGZY)
 
-## Important! 
-CodeGPT extension is **FREE** but the APIs of artificial intelligence providers that it consumes can be paid for.
+:::caution
 
-### OpenAI API
-To use this extension you must have credits loaded into your OpenAI account.
-This extension uses the Official OpenAI API which is a paid API.
+While the CodeGPT extension is free, it requires you to use an API from an external provider (see [Providers](providers.md)). **These external providers are paid services**, although they may offer limited usage for free.
 
-Prices can be found at this link:
-https://openai.com/api/pricing/
+:::
 
-If you do not have credits the extension will show the following OpenAI API error:
-**You exceeded your current quota, please check your plan and billing details**
 
-To review your account and the credits you have available, you must log in with your account at
-
-https://openai.com/api/
-
-In the menu select Manage Account, then in the Usage section, you will be able to see the amount of credits available and used.
-
-![Manage Account](https://user-images.githubusercontent.com/6216945/213941730-b48b8b6a-8f0d-4fea-b4b3-42edc838f42e.png)
-
-In this image you can see that $13 USD has been used out of a total of $18.
-
-![Credits](https://user-images.githubusercontent.com/6216945/213941720-1ae816dd-fedb-4026-ae8c-b8b374d1d0dd.png)
 

--- a/docs/tutorial-ai-providers/openai.md
+++ b/docs/tutorial-ai-providers/openai.md
@@ -6,24 +6,34 @@ sidebar_position: 1
 
 Official website: https://openai.com/
 
-OpenAI is an artificial intelligence research organization that aims to develop and promote friendly AI in a way that benefits all of humanity. They have developed a number of AI models, including GPT-3, which is one of the most advanced natural language processing models in the world. GPT-3 is able to generate human-like text and perform a variety of language tasks, such as language translation and summarization.
+OpenAI is an artificial intelligence research organization that aims to develop and promote friendly AI in a way that benefits all of humanity. They have developed a number of AI models, including GPT-3 and GPT-4, arguably the most advanced natural language processing models in the world.
 
-## GPT-3
-GPT-3 (Generative Pre-trained Transformer 3) is one of the most advanced natural language processing models developed by OpenAI. It can generate human-like text and perform a wide variety of language-based tasks such as language translation, text completion, and summarization. It's also able to answer questions, generate stories and poetry, and even write code. It has been trained on a large corpus of text data and can understand and respond to a wide range of topics.
+## GPT
+GPT (Generative Pre-trained Transformer) is one of the most advanced natural language processing models developed by OpenAI. It can generate human-like text and perform a wide variety of language-based tasks such as language translation, text completion, and summarization. It's also able to answer questions, generate stories and poetry, and even write code. It has been trained on a large corpus of text data and can understand and respond to a wide range of topics.
 
-### Models GPT-3 available in Code GPT
+### GPT models available in Code GPT
 - gpt-4
-- gpt-3.5-turbo-0301
+- gpt-4-32k
 - gpt-3.5-turbo
 - text-davinci-003
 - text-curie-001
 - text-babbage-001
 - text-ada-001
 
+## OpenAI API
 
-## Codex
-Codex is an AI model developed by OpenAI that can generate computer programs. It can take a natural language problem statement and generate a working code that solves the problem. It is trained on a diverse set of code and can generate code in multiple programming languages. It's designed to make programming more accessible by allowing developers to express their ideas in natural language, instead of having to write code themselves.
+To use this extension you must have credits loaded into your OpenAI account.
+This extension uses the Official OpenAI API which is a [paid API](https://openai.com/api/pricing/).
 
-### Models Codex available in Code GPT
-- code-cushman-001
-- code-davinci-002
+If you do not have credits the extension will show the following OpenAI API error:
+**You exceeded your current quota, please check your plan and billing details**
+
+To review your account and the credits you have available, you must log in with your account at https://openai.com/api/
+
+In the menu select Manage Account, then in the Usage section, you will be able to see the amount of credits available and used.
+
+![Manage Account](https://user-images.githubusercontent.com/6216945/213941730-b48b8b6a-8f0d-4fea-b4b3-42edc838f42e.png)
+
+In this image you can see that $13 USD has been used out of a total of $18.
+
+![Credits](https://user-images.githubusercontent.com/6216945/213941720-1ae816dd-fedb-4026-ae8c-b8b374d1d0dd.png)

--- a/docs/tutorial-ai-providers/openai.md
+++ b/docs/tutorial-ai-providers/openai.md
@@ -12,6 +12,7 @@ OpenAI is an artificial intelligence research organization that aims to develop 
 GPT-3 (Generative Pre-trained Transformer 3) is one of the most advanced natural language processing models developed by OpenAI. It can generate human-like text and perform a wide variety of language-based tasks such as language translation, text completion, and summarization. It's also able to answer questions, generate stories and poetry, and even write code. It has been trained on a large corpus of text data and can understand and respond to a wide range of topics.
 
 ### Models GPT-3 available in Code GPT
+- gpt-4
 - gpt-3.5-turbo-0301
 - gpt-3.5-turbo
 - text-davinci-003

--- a/docs/tutorial-basics/configuration.md
+++ b/docs/tutorial-basics/configuration.md
@@ -4,15 +4,30 @@ sidebar_position: 2
 
 # Configuration
 
-## Accessing the Configuration Options
+## Accessing Code GPT's Settings
 1. In Visual Studio Code, click **`File` > `Preferences` > `Settings`**.  This will open the Settings window.  
 2. On the left-hand side of the Settings window, click **`Extensions`**, and then click **`CodeGPT`**.
 
+<details>
+
+<summary>Screenshot: Code GPT Settings</summary>
+
 ![Captura-de-Pantalla-2023-01-04-a-la-s-2-29-15-p-m-](https://user-images.githubusercontent.com/6216945/210634562-1dd5f8cd-4625-42fc-92f4-7e1b5f132c49.png)
 
-## API Key
+</details>
+
+## Available Settings
+
+### API Key
+
 Select your API provider from the dropdown menu. 
-> *See the API Keys the [Installation](./installation.md) section for more information.*
+
+:::info Entering your API Key
+
+*See the [Installation](./installation.md) page for more information about how to set up Code GPT with your API Key.*
+
+:::
+
 ### Max Token
 Tokens can be thought of as pieces of words. Before the API processes the prompts, the input is broken down into tokens.
 

--- a/docs/tutorial-basics/configuration.md
+++ b/docs/tutorial-basics/configuration.md
@@ -4,12 +4,15 @@ sidebar_position: 2
 
 # Configuration
 
-Complete the following information:
+## Accessing the Configuration Options
+1. In Visual Studio Code, click **`File` > `Preferences` > `Settings`**.  This will open the Settings window.  
+2. On the left-hand side of the Settings window, click **`Extensions`**, and then click **`CodeGPT`**.
+
 ![Captura-de-Pantalla-2023-01-04-a-la-s-2-29-15-p-m-](https://user-images.githubusercontent.com/6216945/210634562-1dd5f8cd-4625-42fc-92f4-7e1b5f132c49.png)
 
-### API Key
+## API Key
 Select your API provider from the dropdown menu. 
-> *See the API Keys the [Installation](installation.md) section for more information.*
+> *See the API Keys the [Installation](./installation.md) section for more information.*
 ### Max Token
 Tokens can be thought of as pieces of words. Before the API processes the prompts, the input is broken down into tokens.
 
@@ -19,19 +22,19 @@ Learn more:
 - [Tokens by OpenAI (English)](https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them)
 - [Max Token in Medium (Spanish)](https://medium.com/@dan.avila7/concepto-de-tokens-en-openai-f5d4196076f6)
 
-### Language
+## Query Language
 Select the language in which you will work the interactions with the API.
 
 For functionalities such as Explain or Document, each query will be made in the selected language.
 
-### Model
+## Model
 The service provides access to many different models, grouped by family and ability. A model family typically associates models by their intended task.
 
 Learn more: 
 - [Models by OpenAI (English)](https://beta.openai.com/docs/models/overview)
 - [Model in Medium (Spanish)](https://medium.com/@dan.avila7/modelos-de-gpt-3-y-codex-11a64948d87)
 
-### Temperature
+## Temperature
 This is a parameter that can be adjusted. It determines the level of randomness or "creativity" in the generated text. A higher temperature will result in more varied and creative output, while a lower temperature will produce output that is more similar to the training data and less likely to contain unexpected or surprising content.
 
 It is a value between 0 and 1. 0 being the most deterministic and 1 being the most random and creative. The default temperature is 0.3

--- a/docs/tutorial-basics/configuration.md
+++ b/docs/tutorial-basics/configuration.md
@@ -4,19 +4,12 @@ sidebar_position: 2
 
 # Configuration
 
-Go to **Settings > Extensions > CodeGPT**
-
 Complete the following information:
 ![Captura-de-Pantalla-2023-01-04-a-la-s-2-29-15-p-m-](https://user-images.githubusercontent.com/6216945/210634562-1dd5f8cd-4625-42fc-92f4-7e1b5f132c49.png)
 
-### AI Provider
-Select the AI ​​provider:and then enter the API Key of the selected provider
-- [OpenAI](https://www.codegpt.co/docs/tutorial-ai-providers/openai)
-- [Cohere](https://www.codegpt.co/docs/tutorial-ai-providers/cohere)
 ### API Key
-Enter the API Key of the selected provider
-- To enter your [API Key](/docs/tutorial-basics/installation#get-yout-api-key) press cmd+shift+p and search for `CodeGPT: Set API KEY`. Your API KEY will be safely stored. 
-
+Select your API provider from the dropdown menu. 
+> *See the API Keys the [Installation](installation.md) section for more information.*
 ### Max Token
 Tokens can be thought of as pieces of words. Before the API processes the prompts, the input is broken down into tokens.
 

--- a/docs/tutorial-basics/installation.md
+++ b/docs/tutorial-basics/installation.md
@@ -7,21 +7,23 @@ sidebar_position: 1
 ## Install Visual Studio Code
 Visual Studio Code: [Download](https://code.visualstudio.com/download)
 
-## Download & install Code GPT Extension
-- [Download from Marketplace](https://marketplace.visualstudio.com/items?itemName=DanielSanMedium.dscodegpt)
-- [Download from Open VSX](https://open-vsx.org/extension/DanielSanMedium/dscodegpt)
+## Install the Code GPT Extension
+You can install the extension from the Visual Studio Marketplace, Open VSX, or directly from the Extensions tab in Visual Studio Code.
+- [Download from Marketplace](https://marketplace.visualstudio.com/items?itemName=DanielSanMedium.dscodegpt), or 
+- [Download from Open VSX](https://open-vsx.org/extension/DanielSanMedium/dscodegpt), or
+- Search for Code GPT in the Extensions tab.
 
-Or you can search for Code GPT in the Extensions tab.
 
 ![Extension Tab](https://user-images.githubusercontent.com/6216945/212494271-256734c6-6cab-4c12-bb8f-dae1ffa74b33.png)
 
-## Get your api key
-Select an AI provider:
+## Get your API key
+This will differ depending on the provider you choose:
 - ### OpenAI
-  - Create an account in [openai.com](https://openai.com/api/)
-  - Go to [View API Keys](https://beta.openai.com/account/api-keys)
-  - Press the button **Create a new secret key**
-  - Copy the API Key
+  - Go to the [API Keys page on OpenAI](https://platform.openai.com/account/api-keys).
+  - Log in with your OpenAI account (or [create a new account](https://platform.openai.com/signup))
+  - Click the button labeled **Create a new secret key**
+  - A new dialog window will appear, containing a text box with your API key. 
+  - Copy this API Key to your clipboard.
 
 - ### Cohere
   - Create an account in [cohere.ai](https://cohere.ai/)
@@ -31,12 +33,19 @@ Select an AI provider:
 - ### AI21
   - Create an account in [AI21](https://www.ai21.com/)
   - Go to your [account](https://studio.ai21.com/account/account)
-  - COpu the API Key
+  - Copy the API Key
 
-## Use your API KEY
+## Enter your API Key
+Once you have your API Key, you can enter it into CodeGPT:
+- Open up Visual Studio Code 
+- In VSCode, open the Command Palette (*View>Command Palette* or **⌘+⇧+P**)
+- In the Command Palette, search for `CodeGPT: Set API KEY` and press Enter
+- A new dialog window will appear, prompting you to enter your API Key. 
+- Paste your API Key into the text box and press Enter.
 
-Press **cmd + shift + p** and search for `CodeGPT: Set API KEY`
 
-## Remove your API KEY
 
-If you want to remove your API Key to add a new one, press **cmd + shift + p** and search for `CodeGPT: Remove API KEY`
+>⚠️ If you want to remove your API Key from CodeGPT, open the Command Palette and search for `CodeGPT: Remove API KEY`.
+
+
+

--- a/docs/tutorial-basics/installation.md
+++ b/docs/tutorial-basics/installation.md
@@ -9,19 +9,19 @@ Visual Studio Code: [Download](https://code.visualstudio.com/download)
 
 ## Install the Code GPT Extension
 You can install the extension from the Visual Studio Marketplace, Open VSX, or directly from the Extensions tab in Visual Studio Code.
+- <details>
+      <summary>Search for Code GPT in the Extensions tab, or</summary>
+      <div><img src="https://user-images.githubusercontent.com/6216945/212494271-256734c6-6cab-4c12-bb8f-dae1ffa74b33.png"/></div>
+    </details>
 - [Download from Marketplace](https://marketplace.visualstudio.com/items?itemName=DanielSanMedium.dscodegpt), or 
-- [Download from Open VSX](https://open-vsx.org/extension/DanielSanMedium/dscodegpt), or
-- Search for Code GPT in the Extensions tab.
-
-
-![Extension Tab](https://user-images.githubusercontent.com/6216945/212494271-256734c6-6cab-4c12-bb8f-dae1ffa74b33.png)
+- [Download from Open VSX](https://open-vsx.org/extension/DanielSanMedium/dscodegpt)
 
 ## Get your API key
 This will differ depending on the provider you choose:
 - ### OpenAI
   - Go to the [API Keys page on OpenAI](https://platform.openai.com/account/api-keys).
   - Log in with your OpenAI account (or [create a new account](https://platform.openai.com/signup))
-  - Click the button labeled **Create a new secret key**
+  - Click the button labeled **`Create a new secret key`**
   - A new dialog window will appear, containing a text box with your API key. 
   - Copy this API Key to your clipboard.
 
@@ -38,14 +38,15 @@ This will differ depending on the provider you choose:
 ## Enter your API Key
 Once you have your API Key, you can enter it into CodeGPT:
 - Open up Visual Studio Code 
-- In VSCode, open the Command Palette (*View>Command Palette* or **⌘+⇧+P**)
-- In the Command Palette, search for `CodeGPT: Set API KEY` and press Enter
+- In VSCode, open the Command Palette by clicking **`View` > `Command Palette`** (or use the keyboard shortcut **⌘+⇧+P**)
+- In the Command Palette, search for `CodeGPT: Set API KEY` and press **Enter⏎**
 - A new dialog window will appear, prompting you to enter your API Key. 
-- Paste your API Key into the text box and press Enter.
+- Paste your API Key into the text box and press **Enter⏎**.
 
+:::caution
 
+If you want to remove your API Key from CodeGPT, open the Command Palette and search for `CodeGPT: Remove API KEY`.
 
->⚠️ If you want to remove your API Key from CodeGPT, open the Command Palette and search for `CodeGPT: Remove API KEY`.
-
+:::
 
 


### PR DESCRIPTION
- Corrects menu click-paths for settings and Command palette
- Clarifies instructions for generating and entering an API Key on `installation.md` page
- Moves OpenAI pricing info to existing `/tutorial-ai-provders/openai.md`
- wraps some screenshots in `<details>` elements to improve at-a-glance readability 